### PR TITLE
Docs: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this lesson, please cite it as below."
 type: dataset
-title: "Open Qualitative Research (QualCoder)"
+title: "Open Qualitative Research with Taguette"
 authors:
   - family-names: Porter
     given-names: Nathaniel

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use this lesson, please cite it as below."
+type: dataset
+title: "Open Qualitative Research (QualCoder)"
+authors:
+  - family-names: Porter
+    given-names: Nathaniel
+  - family-names: Karcher
+    given-names: Sebastian
+abstract: "Familiarizes learners with the application of open science principles to qualitative research. Focuses on documents or transcribed text in a variety of data formats. Learners practice working with secondary qualitative data from the Qualitative Data Repository (QDR) in the free software QualCoder."
+keywords:
+  - qualitative research
+  - open science
+  - qualcoder
+  - QDR
+  - coding
+license: CC-BY-4.0
+version: 1.0.0
+date-released: 2025-12-23
+repository-code: "https://github.com/LibraryCarpentry/open-qualitative-research-qualcoder"
+url: "https://librarycarpentry.github.io/open-qualitative-research-qualcoder/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,17 +5,15 @@ title: "Open Qualitative Research (QualCoder)"
 authors:
   - family-names: Porter
     given-names: Nathaniel
-  - family-names: Karcher
-    given-names: Sebastian
 abstract: "Familiarizes learners with the application of open science principles to qualitative research. Focuses on documents or transcribed text in a variety of data formats. Learners practice working with secondary qualitative data from the Qualitative Data Repository (QDR) in the free software QualCoder."
 keywords:
   - qualitative research
   - open science
-  - qualcoder
+  - taguette
   - QDR
   - coding
 license: CC-BY-4.0
 version: 1.0.0
 date-released: 2025-12-23
-repository-code: "https://github.com/LibraryCarpentry/open-qualitative-research-qualcoder"
-url: "https://librarycarpentry.github.io/open-qualitative-research-qualcoder/"
+repository-code: "https://github.com/LibraryCarpentry/lc-qualitative-taguette/"
+url: "https://librarycarpentry.github.io/lc-qualitative-taguette/"


### PR DESCRIPTION
This PR adds a CITATION.cff file to make the lesson citable, generated from the IMLS Open Science project metadata.